### PR TITLE
Update jsonwebtoken dependency version from 0.4.0 to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "html-entities": "^1.3.1",
     "i18n": "^0.11.1",
     "js-yaml": "^3.14.0",
-    "jsonwebtoken": "0.4.0",
+    "jsonwebtoken": "0.1.3",
     "jssha": "^3.1.1",
     "juicy-chat-bot": "~0.8.0",
     "libxmljs": "^1.0.11",


### PR DESCRIPTION
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L155-R155): Downgraded the `jsonwebtoken` package version from `0.4.0` to `0.1.3` to address compatibility issues.